### PR TITLE
[BUGFIX] Use correct hook class for DataHandler hook

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -52,7 +52,7 @@ call_user_func(function () {
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']['list_type_Info'][$listType][JFMULTICONTENT_EXT] = 'JambageCom\\Jfmulticontent\\Hooks\\CmsBackend->getExtensionSummary';
 
     // Save the content
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][JFMULTICONTENT_EXT] = \JambageCom\Jfmulticontent\Hooks\CmsBackend::class;
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][JFMULTICONTENT_EXT] = \JambageCom\Jfmulticontent\Hooks\DataHandler::class;
 
     if ($extensionConfiguration['addBrowseLinks']) {
         // Add browseLinksHook


### PR DESCRIPTION
While migrating several classes and hooks in e1c0da1, the migrated DataHandler hook was not re-registered in `$GLOBALS['TYPO3_CONF_VARS']`. Instead, the hook class `CmsBackend` was used.

The registration of the DataHandler hook has now been streamlined in order to make it work again.